### PR TITLE
Metrics maintenance

### DIFF
--- a/src/mcserver/mcserver.c
+++ b/src/mcserver/mcserver.c
@@ -548,6 +548,9 @@ on_connected(lcbio_SOCKET *sock, void *data, lcb_error_t err, lcbio_OSERR syserr
     procs.cb_flush_ready = on_flush_ready;
     server->connctx = lcbio_ctx_new(sock, server, &procs);
     server->connctx->subsys = "memcached";
+    if (server->pipeline.metrics) {
+        server->connctx->sock->metrics = &server->pipeline.metrics->iometrics;
+    }
     server->pipeline.flush_start = (mcreq_flushstart_fn)mcserver_flush;
 
     tmo = get_next_timeout(server);

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -49,13 +49,9 @@ public:
         for (size_t ii = 0; ii < entries.size(); ++ii) {
             delete entries[ii];
         }
-        if (servers != NULL) {
-            free(servers);
-        }
     }
 
     MetricsEntry *get(const char *host, const char *port, int create) {
-        size_t old_nservers = nservers;
         std::string key;
         key.append(host).append(":").append(port);
         for (size_t ii = 0; ii < entries.size(); ++ii) {
@@ -72,14 +68,7 @@ public:
         entries.push_back(ent);
         raw_entries.push_back(ent);
         nservers = entries.size();
-        servers = (const lcb_SERVERMETRICS**) realloc(servers, nservers * sizeof(*servers));
-        if (servers != NULL) {
-            for (size_t ii = 0; ii < nservers; ++ii) {
-                servers[ii] = entries[ii];
-            }
-        } else {
-            nservers = old_nservers;
-        }
+        servers = (const lcb_SERVERMETRICS**)&raw_entries[0];
         return ent;
     }
 

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -49,9 +49,13 @@ public:
         for (size_t ii = 0; ii < entries.size(); ++ii) {
             delete entries[ii];
         }
+        if (servers != NULL) {
+            free(servers);
+        }
     }
 
     MetricsEntry *get(const char *host, const char *port, int create) {
+        size_t old_nservers = nservers;
         std::string key;
         key.append(host).append(":").append(port);
         for (size_t ii = 0; ii < entries.size(); ++ii) {
@@ -68,6 +72,14 @@ public:
         entries.push_back(ent);
         raw_entries.push_back(ent);
         nservers = entries.size();
+        servers = (const lcb_SERVERMETRICS**) realloc(servers, nservers * sizeof(*servers));
+        if (servers != NULL) {
+            for (size_t ii = 0; ii < nservers; ++ii) {
+                servers[ii] = entries[ii];
+            }
+        } else {
+            nservers = old_nservers;
+        }
         return ent;
     }
 


### PR DESCRIPTION
Maintain server array on server metric addition or removal
Set socket IO metrics on connection to the server when metrics collection is activated
